### PR TITLE
Date dimensions now supported by joining on datekey

### DIFF
--- a/Includes/date_dimensions.view.lkml
+++ b/Includes/date_dimensions.view.lkml
@@ -1,25 +1,5 @@
 view: date_dimensions {
 
-  # datekey the join reference for datedimension
-  dimension_group: date {
-    type: time
-    timeframes: [
-      raw,
-      date,
-      week,
-      month,
-      # quarter,
-      year
-    ]
-    convert_tz: no
-    datatype: date
-    sql: ${TABLE}.datekey ;;
-    group_label:  "Date"
-    # Setting the label to nothing supresses the dimension_groups name appearing before the timeframe in the field label
-    # Without this, labels on these timeframes will appear as "Date Date" and "Date Week", for example.
-    label: ""
-  }
-
   dimension: is_weekend {
     type:  yesno
     sql:  ${TABLE}.isweekend ;;

--- a/Views/service_bc_call_centre.view.lkml
+++ b/Views/service_bc_call_centre.view.lkml
@@ -1,4 +1,9 @@
+include: "/Includes/date_dimensions.view"
+
 view: service_bc_call_centre {
+
+  extends: [date_dimensions]
+
   derived_table: {
     sql: SELECT
           ccl.*,
@@ -14,7 +19,7 @@ view: service_bc_call_centre {
           dd.weekdayname
         FROM servicebc.call_centre AS ccl
         JOIN servicebc.datedimension AS dd
-        ON ccl.datekey::date = dd.datekey::date
+        ON ccl.datekey = dd.datekey
         ;;
   }
 
@@ -57,62 +62,6 @@ view: service_bc_call_centre {
     label: ""
   }
 
-  ## fields joined from servicebc.datedimension
-  dimension: is_weekend {
-    type:  yesno
-    sql:  ${TABLE}.isweekend ;;
-    group_label:  "Date"
-  }
-  dimension: is_holiday {
-    type:  yesno
-    sql:  ${TABLE}.isholiday ;;
-    group_label:  "Date"
-  }
-  dimension: day_of_week {
-    type:  string
-    sql:  ${TABLE}.weekdayname ;;
-    group_label:  "Date"
-  }
-  dimension: day_of_week_number {
-    type: number
-    sql: ${TABLE}.weekday ;;
-    group_label: "Date"
-  }
-  dimension: sbc_quarter {
-    type:  string
-    sql:  ${TABLE}.sbcquarter ;;
-    group_label:  "Date"
-  }
-  dimension: last_day_of_pay_period {
-    type: date
-    sql:  ${TABLE}.lastdayofpsapayperiod ;;
-    group_label: "Date"
-  }
-  dimension: day_of_month {
-    type: number
-    sql: ${TABLE}.day ;;
-    group_label: "Date"
-  }
-  dimension: fiscal_year {
-    type: number
-    sql: ${TABLE}.fiscalyear ;;
-    group_label: "Date"
-  }
-  dimension: fiscal_month {
-    type: number
-    sql: ${TABLE}.fiscalmonth ;;
-    group_label: "Date"
-  }
-  dimension: fiscal_quarter {
-    type: number
-    sql: ${TABLE}.fiscalquarter ;;
-    group_label: "Date"
-  }
-  dimension: fiscal_quarter_of_year {
-    type: string
-    sql:  'Q' || ${fiscal_quarter} ;;
-    group_label:  "Date"
-  }
   dimension: interval {
     sql: ${TABLE}.interval ;;
     type: string

--- a/Views/service_bc_call_centre_calls.view.lkml
+++ b/Views/service_bc_call_centre_calls.view.lkml
@@ -1,22 +1,48 @@
-# include: "/Includes/date_dimensions.view"
+include: "/Includes/date_dimensions.view"
 
 view: service_bc_call_centre_calls {
 
-  # extends: [date_dimensions]
+  extends: [date_dimensions]
 
   derived_table: {
     sql: SELECT
-          cc.*
-        FROM servicebc.call_centre_calls AS cc
+          ccc.*,
+          dd.isweekend::BOOLEAN,
+          dd.isholiday::BOOLEAN,
+          dd.lastdayofpsapayperiod::date,
+          dd.fiscalyear,
+          dd.fiscalmonth,
+          dd.fiscalquarter,
+          dd.sbcquarter,
+          dd.day,
+          dd.weekday,
+          dd.weekdayname
+        FROM servicebc.call_centre_calls_gdxdsd2660 AS ccc
+        JOIN servicebc.datedimension AS dd
+        ON ccc.datekey = dd.datekey
         ;;
   }
 
-  # datekey the join reference for datedimension -- this is currently an INT in the Redshift table which cannot cast to a date and so cannot be joined
-  dimension: datekey {
-    type: number
+  # datekey the join reference for datedimension
+  dimension_group: date {
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      year
+    ]
+    convert_tz: no
+    datatype: date
     sql: ${TABLE}.datekey ;;
     group_label:  "Date"
+    # Setting the label to nothing supresses the dimension_groups name appearing before the timeframe in the field label
+    # Without this, labels on these timeframes will appear as "Date Date" and "Date Week", for example.
+    label: ""
   }
+
+  ## remaining dimensions from call_centre_calls
 
   dimension: id {
     type: number

--- a/Views/service_bc_call_centre_csat.view.lkml
+++ b/Views/service_bc_call_centre_csat.view.lkml
@@ -17,7 +17,7 @@ view: service_bc_call_centre_csat {
           dd.day,
           dd.weekday,
           dd.weekdayname
-        FROM servicebc.call_centre_csat_gdxdxd2660 as csat
+        FROM servicebc.call_centre_csat_gdxdsd2660 as csat
         JOIN servicebc.datedimension AS dd
         ON csat.datekey = dd.datekey
         ;;

--- a/Views/service_bc_call_centre_csat.view.lkml
+++ b/Views/service_bc_call_centre_csat.view.lkml
@@ -1,21 +1,46 @@
-# include: "/Includes/date_dimensions.view"
+include: "/Includes/date_dimensions.view"
 
 view: service_bc_call_centre_csat {
 
-  # extends: [date_dimensions]
+  extends: [date_dimensions]
 
   derived_table: {
     sql: SELECT
-          csat.*
-        FROM servicebc.call_centre_csat as csat
+          csat.*,
+          dd.isweekend::BOOLEAN,
+          dd.isholiday::BOOLEAN,
+          dd.lastdayofpsapayperiod::date,
+          dd.fiscalyear,
+          dd.fiscalmonth,
+          dd.fiscalquarter,
+          dd.sbcquarter,
+          dd.day,
+          dd.weekday,
+          dd.weekdayname
+        FROM servicebc.call_centre_csat_gdxdxd2660 as csat
+        JOIN servicebc.datedimension AS dd
+        ON csat.datekey = dd.datekey
         ;;
   }
 
-  # datekey the join reference for datedimension -- this is currently an INT in the Redshift table which cannot cast to a date and so cannot be joined
-  dimension: datekey {
-    type: number
+  # datekey the join reference for datedimension
+  dimension_group: date {
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      # quarter,
+      year
+    ]
+    convert_tz: no
+    datatype: date
     sql: ${TABLE}.datekey ;;
     group_label:  "Date"
+    # Setting the label to nothing supresses the dimension_groups name appearing before the timeframe in the field label
+    # Without this, labels on these timeframes will appear as "Date Date" and "Date Week", for example.
+    label: ""
   }
 
   dimension: id {

--- a/Views/service_bc_call_centre_esb_data.view.lkml
+++ b/Views/service_bc_call_centre_esb_data.view.lkml
@@ -1,21 +1,46 @@
-# include: "/Includes/date_dimensions.view"
+include: "/Includes/date_dimensions.view"
 
 view: service_bc_call_centre_esb_data {
 
-  # extends: [date_dimensions]
+  extends: [date_dimensions]
 
   derived_table: {
     sql: SELECT
-          esb.*
-        FROM servicebc.call_centre_esb_data as esb
+          esb.*,
+          dd.isweekend::BOOLEAN,
+          dd.isholiday::BOOLEAN,
+          dd.lastdayofpsapayperiod::date,
+          dd.fiscalyear,
+          dd.fiscalmonth,
+          dd.fiscalquarter,
+          dd.sbcquarter,
+          dd.day,
+          dd.weekday,
+          dd.weekdayname
+        FROM servicebc.call_centre_esb_data_gsxdxd2660 as esb
+        JOIN servicebc.datedimension AS dd
+        ON esb.datekey = dd.datekey
         ;;
   }
 
-  # datekey the join reference for datedimension -- this is currently an INT in the Redshift table which cannot cast to a date and so cannot be joined
-  dimension: datekey {
-    type: number
+  # datekey the join reference for datedimension
+  dimension_group: date {
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      # quarter,
+      year
+    ]
+    convert_tz: no
+    datatype: date
     sql: ${TABLE}.datekey ;;
     group_label:  "Date"
+    # Setting the label to nothing supresses the dimension_groups name appearing before the timeframe in the field label
+    # Without this, labels on these timeframes will appear as "Date Date" and "Date Week", for example.
+    label: ""
   }
 
   dimension: id {

--- a/Views/service_bc_call_centre_esb_data.view.lkml
+++ b/Views/service_bc_call_centre_esb_data.view.lkml
@@ -17,7 +17,7 @@ view: service_bc_call_centre_esb_data {
           dd.day,
           dd.weekday,
           dd.weekdayname
-        FROM servicebc.call_centre_esb_data_gsxdsd2660 as esb
+        FROM servicebc.call_centre_esb_data_gdxdsd2660 as esb
         JOIN servicebc.datedimension AS dd
         ON esb.datekey = dd.datekey
         ;;

--- a/Views/service_bc_call_centre_esb_data.view.lkml
+++ b/Views/service_bc_call_centre_esb_data.view.lkml
@@ -17,7 +17,7 @@ view: service_bc_call_centre_esb_data {
           dd.day,
           dd.weekday,
           dd.weekdayname
-        FROM servicebc.call_centre_esb_data_gsxdxd2660 as esb
+        FROM servicebc.call_centre_esb_data_gsxdsd2660 as esb
         JOIN servicebc.datedimension AS dd
         ON esb.datekey = dd.datekey
         ;;

--- a/Views/service_bc_call_centre_escalation.view.lkml
+++ b/Views/service_bc_call_centre_escalation.view.lkml
@@ -1,4 +1,8 @@
+include: "/Includes/date_dimensions.view"
+
 view: service_bc_call_centre_escalation {
+
+  extends: [date_dimensions]
 
   derived_table: {
     sql: SELECT
@@ -9,8 +13,20 @@ view: service_bc_call_centre_escalation {
           escl.receivedtimekey,
           escl.completeddatekey,
           escl.businessdaysaged,
-          escl.resolvedwithinreportingmonth
-        FROM servicebc.call_centre_escalation as escl
+          escl.resolvedwithinreportingmonth,
+          dd.isweekend::BOOLEAN,
+          dd.isholiday::BOOLEAN,
+          dd.lastdayofpsapayperiod::date,
+          dd.fiscalyear,
+          dd.fiscalmonth,
+          dd.fiscalquarter,
+          dd.sbcquarter,
+          dd.day,
+          dd.weekday,
+          dd.weekdayname
+        FROM servicebc.call_centre_escalation_gdxdsd2660 as escl
+        JOIN servicebc.datedimension AS dd
+        ON escl.receiveddatekey = dd.datekey
         ;;
   }
 
@@ -32,9 +48,20 @@ view: service_bc_call_centre_escalation {
     group_label: "Escalation Info"
   }
 
-  dimension: receiveddatekey {
-    type: number
+  dimension_group: receiveddatekey {
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      year
+    ]
+    convert_tz: no
+    datatype: date
     sql: ${TABLE}.receiveddatekey ;;
+    group_label:  "Date"
+    label: "Received"
   }
 
   dimension: receivedtimekey {
@@ -42,9 +69,20 @@ view: service_bc_call_centre_escalation {
     sql: ${TABLE}.receivedtimekey ;;
   }
 
-  dimension: completeddatekey {
-    type: number
+  dimension_group: completeddatekey {
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      year
+    ]
+    convert_tz: no
+    datatype: date
     sql: ${TABLE}.completeddatekey ;;
+    group_label:  "Date"
+    label: "Completed"
   }
 
   dimension: businessdaysaged {


### PR DESCRIPTION
To support testable explores; those testing tables need to be referenced. After approval, I will make a second commit removing `_gdxdsd2660` from the table queries after merging https://github.com/bcgov/GDX-Analytics/pull/225